### PR TITLE
Replace the rm -fr command with a find -delete command so the svn metada...

### DIFF
--- a/tasks/wp_deploy.js
+++ b/tasks/wp_deploy.js
@@ -112,7 +112,7 @@ module.exports = function(grunt) {
 
 			//Clearing trunk
 			grunt.log.writeln( 'Clearing trunk.');
-			exec( 'rm -fr '+svnpath+"/trunk/*" );
+			exec( 'find '+svnpath+"/trunk -not -path '*.svn*' -type f -delete" );
 
 			//grunt.log.writeln( 'Ignoring github specific files and deployment script.');
 			exec( 'svn propset svn:ignore "deploy.sh readme.md .git .gitignore" "'+svnpath+'/trunk/"' );


### PR DESCRIPTION
Replace rm -fr on trunk directory with a find command.

This ensures the subdirectory svn metadata remains intact.

Related to original repo issue #3.