### PR TITLE
added option plugin_main_file to specify a file different than plugin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Default value: `false`
 
 Your plug-in's slug as indicated by its repository url *http://wordpress.org/plugins/{plugin-slug}*
 
+#### options.plugin_main_file
+Type: `String`
+Default value: `false`
+
+Use this option if the name of your plug-in's main file (the PHP file with WordPress plugin headers) differs from the slug name. Pass the full file name with extension, e.g.: *my-plugin.php*
+
 #### options.svn_user
 Type: `String`
 Default value: `false`


### PR DESCRIPTION
hey, 

so I added an option called `plugin_main_file` which is set to false by default; if you put the plugin main filename (inclusive of .php extension)  there, later it will use this var to populate `plugin_file` instead of plugin `slug + ".php"`. If left empty, will default to plugin slug. 

I did not test this but should work, it is rather simple. 

Sorry for the extra insertions/deletions in the commit, I used atom to quickly edit this and it seems it trimmed whitespace in your code.