### PR TITLE
Don't check the README version unless tagging a version

### DIFF
--- a/tasks/wp_deploy.js
+++ b/tasks/wp_deploy.js
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
 			var pluginVersion = plugin.match( new RegExp("^[ \t\/*#@]*Version:\\s*(\\S+)$","im") );
 
 			//Check versions
-			if(  projectVersionCompare( pluginVersion[1],  readmeVersion[1] )  !== 0 ){
+			if( options.deploy_tag && projectVersionCompare( pluginVersion[1],  readmeVersion[1] )  !== 0 ){
 				grunt.log.warn( "Readme.txt version: " + readmeVersion[1] );
 				grunt.log.warn( slug+".php version: " + pluginVersion[1] );
 				grunt.fail.warn( 'Versions do not match:');


### PR DESCRIPTION
The README version should not be checked if no tag is to be deployed. Otherwise it's impossible to update trunk or assets separately.