### PR TITLE
Use `plugin_file` for `pluginVersion` warning

### DIFF
--- a/tasks/wp_deploy.js
+++ b/tasks/wp_deploy.js
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
 			//Check versions
 			if( options.deploy_tag && projectVersionCompare( pluginVersion[1],  readmeVersion[1] )  !== 0 ){
 				grunt.log.warn( "Readme.txt version: " + readmeVersion[1] );
-				grunt.log.warn( plugin_file+".php version: " + pluginVersion[1] );
+				grunt.log.warn( plugin_file+" version: " + pluginVersion[1] );
 				grunt.fail.warn( 'Versions do not match:');
 			}
 

--- a/tasks/wp_deploy.js
+++ b/tasks/wp_deploy.js
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
 			//Check versions
 			if( options.deploy_tag && projectVersionCompare( pluginVersion[1],  readmeVersion[1] )  !== 0 ){
 				grunt.log.warn( "Readme.txt version: " + readmeVersion[1] );
-				grunt.log.warn( slug+".php version: " + pluginVersion[1] );
+				grunt.log.warn( plugin_file+".php version: " + pluginVersion[1] );
 				grunt.fail.warn( 'Versions do not match:');
 			}
 


### PR DESCRIPTION
Using the following Gruntfile configuration:

```js
wp_deploy:{
	trunk: {
		options: {
			build_dir: 'build',
			plugin_main_file: 'bp-loader.php',
			plugin_slug: 'buddypress',
			tmp_dir: 'tmp-wp-deploy'
		}
	}
}
```

If the plugin versions do not match the following output is seen:

```shell
Running "wp_deploy:trunk" (wp_deploy) task
[?] What's your SVN username? fake-username
>> Readme.txt version: 2.7.4
>> buddypress.php version: 2.8.0-alpha
Warning: Versions do not match: Use --force to continue.
```

I expected to see the filename is `bp-loader.php`, not `buddypress.php`:
```shell
Running "wp_deploy:trunk" (wp_deploy) task
[?] What's your SVN username? fake-username
>> Readme.txt version: 2.7.4
>> build/bp-loader.php.php version: 2.8.0-alpha
Warning: Versions do not match: Use --force to continue.
```