### PR TITLE
Use HTTPS for SVN deploy

### DIFF
--- a/tasks/wp_deploy.js
+++ b/tasks/wp_deploy.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
 		var done = this.async();
 
 		var options = this.options({
-			svn_url: "http://plugins.svn.wordpress.org/{plugin-slug}",
+			svn_url: "https://plugins.svn.wordpress.org/{plugin-slug}/",
 			svn_user: false,
 			plugin_main_file: false,
 			plugin_slug: false,


### PR DESCRIPTION
The README says:

> #### options.svn_url
> Type: `String`
> Default value: `https://plugins.svn.wordpress.org/{plugin-slug}`

But I found HTTPS was not actually in use, which is important since the script prompts you for your WordPress.org password.