### PR TITLE
Update inquirer to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt": ">=0.4.1"
   },
   "dependencies": {
-    "inquirer": "~0.2.1"
+    "inquirer": "^6.0.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Fixes issue #40 

This updates inquirer to version 6.0.0. There don't appear to have been any API changes to the `inquirer.prompt()` method that is in use.

Running `grunt test` shows that all unit tests pass still.