### PR TITLE
Avoid checking out the whole repo, use remote tagging

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,7 +66,7 @@ module.exports = function(grunt) {
     wp_deploy: {
 		first: { //First standard test
 			options: {
-				svn_url: 'file://' + path.resolve() + '/tmp/repo/standard',
+				svn_url: 'file://' + path.resolve() + '/tmp/repo/standard/',
 				plugin_slug: 'standard',
 				svn_user: 'stephenharris',  
 				skip_confirmation: true,
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
 		},
 		second: { //Second commit (standard test)
 			options: {
-				svn_url: 'file://' + path.resolve() + '/tmp/repo/standard',
+				svn_url: 'file://' + path.resolve() + '/tmp/repo/standard/',
 				plugin_slug: 'standard',
 				svn_user: 'stephenharris',  
 				skip_confirmation: true,
@@ -90,7 +90,7 @@ module.exports = function(grunt) {
 		},
 		alt_filenames: { //Testing deployments using alternative readme file (i.e. not readme.txt) and alternative main plug-in file.
 			options: {
-				svn_url: 'file://' + path.resolve() + '/tmp/repo/alt-filenames',
+				svn_url: 'file://' + path.resolve() + '/tmp/repo/alt-filenames/',
 				plugin_slug: 'alt-filenames',
 				plugin_main_file: 'alt-plugin-main-file.php',
 				svn_user: 'stephenharris',  

--- a/tasks/wp_deploy.js
+++ b/tasks/wp_deploy.js
@@ -126,15 +126,15 @@ module.exports = function(grunt) {
 				function( callback ) {
 					callback( null, ctxt );
 				},
-				checkOut,
+				checkOutTrunk,
 				options.deploy_trunk ? clearTrunk : null,
 				options.deploy_trunk ? copyBuild : null,
+				options.assets_dir ? checkOutAssets : null,
 				options.assets_dir ? clearAssets : null,
 				options.assets_dir ? copyAssets : null,
 				options.skip_confirmation ? null : confirmation,
 				options.deploy_trunk ? addFiles : null,
 				options.deploy_trunk ? commitToTrunk : null,
-				options.deploy_tag ? copyToTag : null,
 				options.deploy_tag ? commitTag : null,
 				options.assets_dir ? addAssets : null,
 				options.assets_dir ? commitAssets : null
@@ -148,18 +148,15 @@ module.exports = function(grunt) {
 
 	}); //Register
 
-	var checkOut = function ( ctxt, callback ) {
-		grunt.log.writeln( 'Checking out '+ ctxt.svnurl+ '...' );
-		exec( 'svn co ' + ctxt.force_interactive + ' '+ctxt.svnurl+ ' ' + ctxt.svnpath, { maxBuffer: ctxt.max_buffer }, function (error, stdout, stderr) {
+	var checkOutTrunk = function ( ctxt, callback ) {
+		grunt.log.writeln( 'Checking out '+ ctxt.svnurl+ 'trunk/...' );
+		exec( 'svn co ' + ctxt.force_interactive + ' '+ctxt.svnurl+ 'trunk/ ' + ctxt.svnpath + '/trunk/', { maxBuffer: ctxt.max_buffer }, function (error, stdout, stderr) {
 			if (error !== null) {
-				grunt.fail.fatal( 'Checkout of "'+ctxt.svnurl+'"unsuccessful: ' + error);
+				grunt.fail.fatal( 'Checkout of "'+ctxt.svnurl+'trunk/" unsuccessful: ' + error);
 			}
 
 			grunt.log.writeln( 'Check out complete.' + "\n" );
 
-			if( ctxt.deploy_tag && grunt.file.exists(  ctxt.svnpath+"/tags/"+ctxt.new_version) ){
-				grunt.fail.warn( 'Tag ' + ctxt.new_version + ' already exists');
-			}
 			callback( null, ctxt );
 		});
 	};
@@ -171,6 +168,19 @@ module.exports = function(grunt) {
 		});
 	};
 	
+	var checkOutAssets = function ( ctxt, callback ) {
+		grunt.log.writeln( 'Checking out '+ ctxt.svnurl+ 'assets/...' );
+		exec( 'svn co ' + ctxt.force_interactive + ' '+ctxt.svnurl+ 'assets/ ' + ctxt.svnpath + '/assets/', { maxBuffer: ctxt.max_buffer }, function (error, stdout, stderr) {
+			if (error !== null) {
+				grunt.fail.fatal( 'Checkout of "'+ctxt.svnurl+'assets/" unsuccessful: ' + error);
+			}
+
+			grunt.log.writeln( 'Check out complete.' + "\n" );
+
+			callback( null, ctxt );
+		});
+	};
+
 	var clearAssets = function ( ctxt, callback ) {
 		grunt.log.writeln( 'Clearing assets.');
 		exec( 'rm -fr '+ctxt.svnpath+"/assets/*", function(){
@@ -230,23 +240,13 @@ module.exports = function(grunt) {
 		});
 	};
 
-	var copyToTag = function( ctxt, callback ) {
-		grunt.log.writeln( 'Copying ' + ctxt.new_version + ' to tag');
-		exec( "svn copy trunk/ tags/"+ctxt.new_version, { cwd: ctxt.svnpath }, function( error, stdout, stderr) {
-			if (error !== null) {
-				grunt.fail.warn( 'Failed to copy to tag: ' + error );
-			}
-			callback( null, ctxt );
-		});
-	};
-
 	var commitTag = function( ctxt, callback ) {
 		var tagCommitMsg   = "Tagging " + ctxt.new_version;
 		grunt.log.writeln( tagCommitMsg + "\n" );
-		var cmd = 'svn commit ' + ctxt.force_interactive + ' --username="'+ctxt.svnuser+'" -m "'+tagCommitMsg+'"';
-		exec( cmd , { cwd: ctxt.svnpath+'/tags/'+ctxt.new_version }, function( error, stdout, stderr) {
+		var cmd = 'svn copy ' + ctxt.svnurl + 'trunk/ ' + ctxt.svnurl + 'tags/' + ctxt.new_version + '/ ' + ctxt.force_interactive + ' --username="'+ctxt.svnuser+'" -m "'+tagCommitMsg+'"';
+		exec( cmd , { cwd: ctxt.svnpath }, function( error, stdout, stderr) {
 			if (error !== null) {
-				grunt.fail.warn( 'Failed to comit tag: ' + error );
+				grunt.fail.warn( 'Failed to commit tag: ' + error );
 			}
 			callback( null, ctxt );
 		});

--- a/tasks/wp_deploy.js
+++ b/tasks/wp_deploy.js
@@ -126,6 +126,7 @@ module.exports = function(grunt) {
 				function( callback ) {
 					callback( null, ctxt );
 				},
+				options.deploy_tag ? checkTag : null,
 				checkOutTrunk,
 				options.deploy_trunk ? clearTrunk : null,
 				options.deploy_trunk ? copyBuild : null,
@@ -235,6 +236,18 @@ module.exports = function(grunt) {
 		exec( cmd, {cwd:ctxt.svnpath+'/trunk'}, function(error, stdout, stderr) {
 			if (error !== null) {
 				grunt.fail.warn( 'Failed to commit to trunk: ' + error );
+			}
+			callback( null, ctxt );
+		});
+	};
+
+	var checkTag = function( ctxt, callback ) {
+		var tagCheckMsg   = "Checking tag " + ctxt.new_version;
+		grunt.log.writeln( tagCheckMsg + "\n" );
+		var cmd = 'svn co ' + ctxt.svnurl + 'tags/' + ctxt.new_version + '/ ' + ctxt.svnpath + '/' + ctxt.new_version + '/ --username="'+ctxt.svnuser+'"';
+		exec( cmd, function( error, stdout, stderr) {
+			if (error === null) {
+				grunt.fail.fatal( 'Tag already exists' );
 			}
 			callback( null, ctxt );
 		});


### PR DESCRIPTION
This library performs a full checkout of the plugin. This can take a _very_ long time if the plugin has many tags, a large number of files, or both.

This proposed change switches to only checking out `trunk` and `assets`, and using SVN's remote copying feature to copy `trunk` to `tags/x.y.z` on the remote server.

By removing the need to checkout the whole plugin it speeds up the whole process hugely, regardless of whether you're deploying just to trunk or tagging too.

Unfortunately I haven't been able to get the tests passing, mainly because I've had a hard time understanding exactly how they work. Any pointers would be appreciated.